### PR TITLE
refactor(adfluxbackend): 调整广告分类接口位置，优化用户注册参数校验

### DIFF
--- a/src/main/java/com/usst/adfluxbackend/config/JsonConfig.java
+++ b/src/main/java/com/usst/adfluxbackend/config/JsonConfig.java
@@ -1,0 +1,27 @@
+package com.usst.adfluxbackend.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.boot.jackson.JsonComponent;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+
+/**
+ * Spring MVC json配置
+ */
+@Configuration
+public class JsonConfig {
+
+    @Bean
+    public Jackson2ObjectMapperBuilderCustomizer jackson2ObjectMapperBuilderCustomizer() {
+        return builder -> {
+            // 将 Long 类型序列化为 String
+            builder.serializerByType(Long.class, ToStringSerializer.instance);
+            // 将 long 基本类型序列化为 String
+            builder.serializerByType(Long.TYPE, ToStringSerializer.instance);
+        };
+    }
+}

--- a/src/main/java/com/usst/adfluxbackend/controller/AdminController.java
+++ b/src/main/java/com/usst/adfluxbackend/controller/AdminController.java
@@ -65,22 +65,6 @@ public class AdminController {
     }
     
     /**
-     * 获取广告分类列表
-     *
-     * @return 广告分类列表
-     */
-    @GetMapping("/categories")
-    public BaseResponse<List<CategoryVO>> listAllCategories() {
-        List<AdCategories> categories = adCategoriesService.listAllCategories();
-        List<CategoryVO> categoryVOS = categories.stream().map(category -> {
-            CategoryVO vo = new CategoryVO();
-            BeanUtils.copyProperties(category, vo);
-            return vo;
-        }).collect(Collectors.toList());
-        return ResultUtils.success(categoryVOS);
-    }
-    
-    /**
      * 新增广告分类
      *
      * @param createRequest 创建分类请求

--- a/src/main/java/com/usst/adfluxbackend/controller/AdvertiserController.java
+++ b/src/main/java/com/usst/adfluxbackend/controller/AdvertiserController.java
@@ -7,11 +7,14 @@ import com.usst.adfluxbackend.model.dto.ad.*;
 import com.usst.adfluxbackend.model.dto.advertiser.AdvertiserAddRequest;
 import com.usst.adfluxbackend.model.dto.payment.PaymentMethodAddRequest;
 import com.usst.adfluxbackend.model.dto.statistic.DataOverviewQueryRequest;
+import com.usst.adfluxbackend.model.entity.AdCategories;
 import com.usst.adfluxbackend.model.entity.AdvertiserPayments;
 import com.usst.adfluxbackend.model.vo.*;
+import com.usst.adfluxbackend.service.AdCategoriesService;
 import com.usst.adfluxbackend.service.AdvertisersService;
 import com.usst.adfluxbackend.service.AdvertiserPaymentsService;
 import com.usst.adfluxbackend.service.AdvertisementsService;
+import org.springframework.beans.BeanUtils;
 import org.springframework.web.bind.annotation.*;
 
 import javax.annotation.Resource;
@@ -30,6 +33,9 @@ public class AdvertiserController {
     
     @Resource
     private AdvertisementsService advertisementsService;
+
+    @Resource
+    private AdCategoriesService adCategoriesService;
 
     /**
      * 获取广告主公司信息
@@ -219,5 +225,21 @@ public class AdvertiserController {
                                                                              DataOverviewQueryRequest queryRequest) {
         AdvertisementStatisticsVO statisticsVO = advertisementsService.getAdvertisementStatistics(adId, queryRequest);
         return ResultUtils.success(statisticsVO);
+    }
+
+    /**
+     * 获取广告分类列表
+     *
+     * @return 广告分类列表
+     */
+    @GetMapping("/categories")
+    public BaseResponse<List<CategoryVO>> listAllCategories() {
+        List<AdCategories> categories = adCategoriesService.listAllCategories();
+        List<CategoryVO> categoryVOS = categories.stream().map(category -> {
+            CategoryVO vo = new CategoryVO();
+            BeanUtils.copyProperties(category, vo);
+            return vo;
+        }).collect(Collectors.toList());
+        return ResultUtils.success(categoryVOS);
     }
 }

--- a/src/main/java/com/usst/adfluxbackend/model/dto/admin/AdReviewRequest.java
+++ b/src/main/java/com/usst/adfluxbackend/model/dto/admin/AdReviewRequest.java
@@ -11,7 +11,7 @@ import java.io.Serializable;
 public class AdReviewRequest implements Serializable {
 
     /**
-     * 审核结果：1-通过；2-拒绝
+     * 审核结果：0-待审核；1-通过；2-拒绝
      */
     private Integer reviewStatus;
 

--- a/src/main/java/com/usst/adfluxbackend/service/impl/AdvertisementsServiceImpl.java
+++ b/src/main/java/com/usst/adfluxbackend/service/impl/AdvertisementsServiceImpl.java
@@ -435,7 +435,7 @@ public class AdvertisementsServiceImpl extends ServiceImpl<AdvertisementsMapper,
      * 管理员审核广告
      *
      * @param adId 广告ID
-     * @param reviewStatus 审核状态：1-通过；2-拒绝
+     * @param reviewStatus 审核状态：0-待审核；1-通过；2-拒绝
      * @param reason 拒绝原因
      * @return 更新后的广告信息
      */

--- a/src/main/java/com/usst/adfluxbackend/service/impl/UsersServiceImpl.java
+++ b/src/main/java/com/usst/adfluxbackend/service/impl/UsersServiceImpl.java
@@ -3,6 +3,7 @@ package com.usst.adfluxbackend.service.impl;
 import cn.hutool.core.bean.BeanUtil;
 import cn.hutool.core.util.StrUtil;
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.core.toolkit.StringUtils;
 import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
 import com.usst.adfluxbackend.context.BaseContext;
 import com.usst.adfluxbackend.exception.BusinessException;
@@ -71,8 +72,8 @@ public class UsersServiceImpl extends ServiceImpl<UsersMapper, Users>
         }
         String username = userRegisterRequest.getUsername();
         String userPassword = userRegisterRequest.getUserPassword();
-        if (username.length() < 4) {
-            throw new BusinessException(ErrorCode.PARAMS_ERROR, "用户名过短");
+        if (StringUtils.isBlank(username) || username.length() < 4) {
+            throw new BusinessException(ErrorCode.PARAMS_ERROR, "用户名过短/用户名为空");
         }
         if (userPassword.length() < 8) {
             throw new BusinessException(ErrorCode.PARAMS_ERROR, "用户密码过短");
@@ -105,7 +106,7 @@ public class UsersServiceImpl extends ServiceImpl<UsersMapper, Users>
         boolean saveResult = this.save(user);
         if (!saveResult) {
             throw new BusinessException(ErrorCode.SYSTEM_ERROR, "注册失败，数据库错误");
-}
+        }
         return user.getUserId();
     }
 
@@ -132,7 +133,7 @@ public class UsersServiceImpl extends ServiceImpl<UsersMapper, Users>
         // 4. 保存用户的登录态 用于判断用户是否登录
         Map<String, Object> jwtClaims = new HashMap<>();
         jwtClaims.put("userId", user.getUserId());
-jwtClaims.put("username", username);
+        jwtClaims.put("username", username);
         jwtClaims.put("userRole", user.getUserRole());
         // 生成token
         String token = jwtUtils.generateToken(jwtClaims);


### PR DESCRIPTION
- 将广告分类接口从AdminController移动到AdvertiserController
- 更新广告审核状态枚举，新增待审核状态
- 配置Jackson将Long类型序列化为String
- 优化用户注册参数校验逻辑，增加用户名非空判断