### PR TITLE
feat(datasource): 增加 Hikari 连接池的 max-lifetime 和 keepalive-time 配置

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,7 +18,9 @@ spring:
     username: ${adflux.datasource.username}
     password: ${adflux.datasource.password}
     hikari:
-      keepalive-time: 180000
+      # MySQL 默认通常是 28800秒 (8小时)，这里设为 10-30 分钟比较稳妥
+      max-lifetime: 600000 # 10分钟 存活时间 10分钟又重新创建
+      keepalive-time: 180000 # 3分钟心跳 防止mysql断开
   # 开放更大的文件上传体积
   servlet:
     multipart:


### PR DESCRIPTION
- 添加 max-lifetime 配置，设置连接最大存活时间为 10 分钟，以避免 MySQL 默认 8 小时的超时问题
- 保留 keepalive-time 配置，设置为 3 分钟，用于防止 MySQL 断开连接
- 这些调整可以提高数据库连接的稳定性和响应速度